### PR TITLE
Feature/add tags for matatika datasets based on dbt node type

### DIFF
--- a/dbt_artifacts_ext/converter/__init__.py
+++ b/dbt_artifacts_ext/converter/__init__.py
@@ -31,6 +31,7 @@ class ConversionContext:
     identifier: Any
     metadata: dict
     description: "list[str]"
+    tags: "list[str]"
     data: Any
 
 

--- a/dbt_artifacts_ext/converter/matatika.py
+++ b/dbt_artifacts_ext/converter/matatika.py
@@ -35,11 +35,12 @@ class MatatikaConverter(MermaidConverter):
                 result_description.extend(result.description)
                 description_parts.append('\n'.join(result_description))
 
-            description_parts.append('\n\n\n #dbt_artifacts')
+            result.tags.append("dbt")
 
             dataset = DatasetV0_2()
             dataset.title = result.metadata.get("name") or result.identifier
             dataset.description = '\n\n'.join(p for p in description_parts if p)
+            dataset.description += '\n\n' + ' '.join(f"#{t}" for t in result.tags if t)
             dataset.source = DEFAULT_SOURCE
             dataset.visualisation = json.dumps({"mermaid": {}}, indent=INDENT)
             dataset.raw_data = result.data

--- a/dbt_artifacts_ext/converter/mermaid.py
+++ b/dbt_artifacts_ext/converter/mermaid.py
@@ -111,6 +111,7 @@ class MermaidConverter(Converter):
                         table_data["unique_id"],
                         table_data,
                         description,
+                        [resource_type],
                         "\n".join(lines),
                     )
                 )
@@ -129,6 +130,7 @@ class MermaidConverter(Converter):
                     package_name,
                     metadata,
                     description,
+                    self.resource_types,
                     "\n".join(full_lines),
                 )
             )

--- a/dbt_artifacts_ext/tests/test_dataset.py
+++ b/dbt_artifacts_ext/tests/test_dataset.py
@@ -31,3 +31,17 @@ def test_convert_without_model_and_column_descriptions():
     dataset_description: str = context_without_description.data["description"]
 
     assert dataset_description.startswith('| Column |')
+
+
+def test_convert_gets_correct_tags():
+    converter = MatatikaConverter()
+    converter.load_artifacts()
+
+    contexts = converter.convert()
+    model_type_context = contexts[1]
+    test_type_contest = contexts[3]
+    source_type_context = contexts[5]
+
+    assert '#test' in test_type_contest.data["description"]
+    assert '#model' in model_type_context.data["description"]
+    assert '#source' in source_type_context.data["description"]

--- a/dbt_artifacts_ext/tests/test_dataset.py
+++ b/dbt_artifacts_ext/tests/test_dataset.py
@@ -41,7 +41,9 @@ def test_convert_gets_correct_tags():
     model_type_context = contexts[1]
     test_type_contest = contexts[3]
     source_type_context = contexts[5]
+    project_context = contexts[7]
 
     assert '#test' in test_type_contest.data["description"]
     assert '#model' in model_type_context.data["description"]
     assert '#source' in source_type_context.data["description"]
+    assert all(tag in project_context.data["description"] for tag in ["#test", "#model", "#source"])


### PR DESCRIPTION
- Added tags for use in Matatika dataset descriptions based on the dbt artifacts type
- Added test that asserts the correct tags are added for across a range of dbt artifacts